### PR TITLE
Replace `fregante/setup-git-token` with `setup-git-user`

### DIFF
--- a/.github/workflows/covid-polls.yml
+++ b/.github/workflows/covid-polls.yml
@@ -18,9 +18,7 @@ jobs:
     steps:
     - uses: actions/checkout@v2
        #set up username and id 
-    - uses: fregante/setup-git-token@v1
-      with:
-         token: ${{ secrets.GITHUB_TOKEN }}
+    - uses: fregante/setup-git-user@v1
     - name: pull data via curl
       run: |
        git remote add github "https://$GITHUB_ACTOR:$GITHUB_TOKEN@github.com/$GITHUB_REPOSITORY.git"
@@ -63,9 +61,7 @@ jobs:
     steps:
     - uses: actions/checkout@v2
        #set up username and id 
-    - uses: fregante/setup-git-token@v1
-      with:
-         token: ${{ secrets.GITHUB_TOKEN }}
+    - uses: fregante/setup-git-user@v1
     - name: pull data via curl
       run: |
        git remote add github "https://$GITHUB_ACTOR:$GITHUB_TOKEN@github.com/$GITHUB_REPOSITORY.git"
@@ -108,9 +104,7 @@ jobs:
     steps:
     - uses: actions/checkout@v2
        #set up username and id 
-    - uses: fregante/setup-git-token@v1
-      with:
-         token: ${{ secrets.GITHUB_TOKEN }}
+    - uses: fregante/setup-git-user@v1
     - name: pull data via curl
       run: |
        git remote add github "https://$GITHUB_ACTOR:$GITHUB_TOKEN@github.com/$GITHUB_REPOSITORY.git"
@@ -152,9 +146,7 @@ jobs:
     steps:
     - uses: actions/checkout@v2
        #set up username and id 
-    - uses: fregante/setup-git-token@v1
-      with:
-         token: ${{ secrets.GITHUB_TOKEN }}
+    - uses: fregante/setup-git-user@v1
     - name: pull data via curl
       run: |
        git remote add github "https://$GITHUB_ACTOR:$GITHUB_TOKEN@github.com/$GITHUB_REPOSITORY.git"
@@ -196,9 +188,7 @@ jobs:
     steps:
     - uses: actions/checkout@v2
        #set up username and id 
-    - uses: fregante/setup-git-token@v1
-      with:
-         token: ${{ secrets.GITHUB_TOKEN }}
+    - uses: fregante/setup-git-user@v1
     - name: pull data via curl
       run: |
        git remote add github "https://$GITHUB_ACTOR:$GITHUB_TOKEN@github.com/$GITHUB_REPOSITORY.git"
@@ -240,9 +230,7 @@ jobs:
     steps:
     - uses: actions/checkout@v2
        #set up username and id 
-    - uses: fregante/setup-git-token@v1
-      with:
-         token: ${{ secrets.GITHUB_TOKEN }}
+    - uses: fregante/setup-git-user@v1
     - name: pull data via curl
       run: |
        git remote add github "https://$GITHUB_ACTOR:$GITHUB_TOKEN@github.com/$GITHUB_REPOSITORY.git"

--- a/.github/workflows/fiveThirtyEightIngestion.yml
+++ b/.github/workflows/fiveThirtyEightIngestion.yml
@@ -20,9 +20,7 @@ jobs:
     steps:
     - uses: actions/checkout@v2
        #set up username and id 
-    - uses: fregante/setup-git-token@v1
-      with:
-         token: ${{ secrets.GITHUB_TOKEN }}
+    - uses: fregante/setup-git-user@v1
     - name: pull data via curl
       run: |
        git remote add github "https://$GITHUB_ACTOR:$GITHUB_TOKEN@github.com/$GITHUB_REPOSITORY.git"
@@ -65,9 +63,7 @@ jobs:
     steps:
     - uses: actions/checkout@v2
        #set up username and id 
-    - uses: fregante/setup-git-token@v1
-      with:
-         token: ${{ secrets.GITHUB_TOKEN }}
+    - uses: fregante/setup-git-user@v1
     - name: pull data via curl
       run: |
        git remote add github "https://$GITHUB_ACTOR:$GITHUB_TOKEN@github.com/$GITHUB_REPOSITORY.git"
@@ -110,9 +106,7 @@ jobs:
     steps:
     - uses: actions/checkout@v2
        #set up username and id 
-    - uses: fregante/setup-git-token@v1
-      with:
-         token: ${{ secrets.GITHUB_TOKEN }}
+    - uses: fregante/setup-git-user@v1
     - name: pull data via curl
       run: |
        git remote add github "https://$GITHUB_ACTOR:$GITHUB_TOKEN@github.com/$GITHUB_REPOSITORY.git"
@@ -154,9 +148,7 @@ jobs:
     steps:
     - uses: actions/checkout@v2
        #set up username and id 
-    - uses: fregante/setup-git-token@v1
-      with:
-         token: ${{ secrets.GITHUB_TOKEN }}
+    - uses: fregante/setup-git-user@v1
     - name: pull data via curl
       run: |
        git remote add github "https://$GITHUB_ACTOR:$GITHUB_TOKEN@github.com/$GITHUB_REPOSITORY.git"
@@ -198,9 +190,7 @@ jobs:
     steps:
     - uses: actions/checkout@v2
        #set up username and id 
-    - uses: fregante/setup-git-token@v1
-      with:
-         token: ${{ secrets.GITHUB_TOKEN }}
+    - uses: fregante/setup-git-user@v1
     - name: pull data via curl
       run: |
        git remote add github "https://$GITHUB_ACTOR:$GITHUB_TOKEN@github.com/$GITHUB_REPOSITORY.git"


### PR DESCRIPTION
Thanks to `actions/checkout@v2`, setting the token is no longer necessary, so I created a new config-less action to just set the git user: https://github.com/fregante/setup-git-user